### PR TITLE
Feat/writing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import Register from './routes/Register';
 import Chatbot from './routes/Chatbot';
 import useReissue from './hooks/useReissue';
 import ChatProf from './routes/ChatProf';
+import Writing from './routes/Writing';
 
 function App() {
   const showAside = useShowAside();
@@ -24,7 +25,9 @@ function App() {
         <Route path="/chatbot" element={<Chatbot />} />
         <Route path="/chatprof" element={<ChatProf/>} />
         <Route path="/file" element={""} />
-        <Route path="/writing" element={""} />
+        <Route path="/writing" element={<Writing />}>
+          <Route path=":writingId" element={<Writing />} />
+        </Route>
         <Route path="/redirect/:option" element={<Redirect />} />
       </Routes>
     </div>

--- a/src/api/writingApi.js
+++ b/src/api/writingApi.js
@@ -1,0 +1,76 @@
+const getWritingList = async (accessToken) => {
+    const res = await fetch(import.meta.env.VITE_APP_WRITING_API_URL + '/api/student/list', {
+      headers: {
+        method: 'GET',
+        Authorization: `Bearer ${accessToken}`,
+      }
+    });
+  
+    if (!res.ok) {
+      const message = (await res.json()).message;
+      throw new Error(message);
+    }
+  
+    return res.json();
+}
+
+const getWriting = async (accessToken,assignmentId) => {
+    const res = await fetch(`${import.meta.env.VITE_APP_WRITING_API_URL}/api/student?assignmentId=${assignmentId}`, {
+      headers: {
+        method: 'GET',
+        Authorization: `Bearer ${accessToken}`,
+      }
+    });
+  
+    if (!res.ok) {
+      const message = (await res.json()).message;
+      throw new Error(message);
+    }
+  
+    return res.json();
+}
+
+const postWriting = async (accessToken,assignmentId, writingState, content) => {
+    const res = await fetch(import.meta.env.VITE_APP_WRITING_API_URL + '/api/student', {
+      method: 'POST',
+      headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({ 
+        assignmentId: assignmentId,
+        writingState: writingState,
+        content: content,
+      }),
+    });
+  
+    if (!res.ok) {
+      const message = (await res.json()).message;
+      throw new Error(message);
+    }
+  
+    return res.json();
+}
+
+const getFeedback = async (accessToken, assignmentId, content) => {
+  const res = await fetch(import.meta.env.VITE_APP_WRITING_API_URL + '/api/student/feedback', {
+      method: 'POST',
+      headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({ 
+        assignmentId: assignmentId,
+        content: content,
+      }),
+    });
+
+    if (!res.ok) {
+      const message = (await res.json()).message;
+      throw new Error(message);
+    }
+
+    return res.json();
+}
+
+export { getWritingList, getWriting, postWriting, getFeedback };

--- a/src/components/aside/Aside.css
+++ b/src/components/aside/Aside.css
@@ -110,3 +110,21 @@
   background-color: #65FF4D;
   margin-left: auto;
 }
+
+.aside-extend-menu {
+  width: 280px;
+  height: 100dvh;
+  transition: all 0.5s;
+  border-radius: 0 30px 30px 0;
+  background: #193553;
+  position: fixed;
+  top: 0;
+  z-index: 800;
+  padding: 28px;
+  box-sizing: border-box;
+}
+
+.aside-extend-menu.active {
+  width: 560px;
+  padding-left: calc(280px + 28px);
+}

--- a/src/components/aside/Aside.jsx
+++ b/src/components/aside/Aside.jsx
@@ -7,10 +7,13 @@ import writingIcon from '../../assets/icons/writing-icon.png';
 import { Link, useNavigate } from 'react-router-dom';
 import useCurrentPath from '../../hooks/useCurrentPath';
 import useLastCommentStore from '../../store/useLastCommenStore';
+import useShowExtend from '../../hooks/useShowExtend';
+import WritingMenu from './WritingMenu/WritingMenu';
 
 function Aside() {
   const currentPath = useCurrentPath();
   const navigate = useNavigate();
+  const showExtend = useShowExtend();
   const lastCommentIsQuestion = useLastCommentStore((state) => state.lastCommentIsQuestion);
 
   const handleLogout = () => {
@@ -62,8 +65,14 @@ function Aside() {
           </li>
         </ul>
       </section>
-      <section>
-
+      <section className={'aside-extend-menu ' + (
+        showExtend ?
+        'active' : null
+        )}>
+          {
+            currentPath === 'writing' ? 
+            <WritingMenu /> : null
+          }
       </section>
     </aside>
   )

--- a/src/components/aside/WritingMenu/WritingItem.css
+++ b/src/components/aside/WritingMenu/WritingItem.css
@@ -1,0 +1,43 @@
+.writing-item {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    font-size: 14px;
+    color: #fff;
+    font-weight: 400;
+    padding: 0 10px;
+    border-radius: 10px;
+    cursor: pointer;
+}
+.writing-week {
+    font-size: 14px;
+    color: #fff;
+    font-weight: 400;
+}
+.writing-item:hover {
+    background-color: #465F7A;
+}
+.writing-state-title {
+    font-size: 12px;
+    color: #fff;
+}
+.writing-state-color {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    margin-left: 5px;
+    display: inline-block;
+}
+.writing-state-color.submitted {
+    background-color: #65FF4D;
+}
+.writing-state-color.approved{
+    background-color: #FFA24D;
+}
+.writing-state-color.not-approved{
+    background-color: #FF4D4D;
+}
+.writing-state-color.not-submitted{
+    background-color: transparent;
+}

--- a/src/components/aside/WritingMenu/WritingItem.jsx
+++ b/src/components/aside/WritingMenu/WritingItem.jsx
@@ -1,21 +1,11 @@
 /* eslint-disable react/prop-types */
 import './WritingItem.css';
+import { writingStateEnum} from '../../../utils/writingEnum';
 
 const WritingItem = ({ item, onClick}) => {
-    const getStateText = (writingState) => {
-        switch (writingState) {
-            case 0:
-                return { text: '', className: 'not-submitted' };
-            case 1:
-                return { text: '제출완료', className: 'submitted' };
-            case 2:
-                return { text: '부정제출', className: 'not-approved' };
-            case 3:
-                return { text: '제출승인', className: 'approved' };
-        }
-    };
+    const state = Object.values(writingStateEnum).find(state => state.state === item.writingState) || {};
 
-    const { text, className } = getStateText(item.writingState);
+    const { text = '', className = '' } = state;
 
     return (
         <li className={`writing-item ${className}`} onClick={onClick}>

--- a/src/components/aside/WritingMenu/WritingItem.jsx
+++ b/src/components/aside/WritingMenu/WritingItem.jsx
@@ -1,0 +1,31 @@
+/* eslint-disable react/prop-types */
+import './WritingItem.css';
+
+const WritingItem = ({ item, onClick}) => {
+    const getStateText = (writingState) => {
+        switch (writingState) {
+            case 0:
+                return { text: '', className: 'not-submitted' };
+            case 1:
+                return { text: '제출완료', className: 'submitted' };
+            case 2:
+                return { text: '부정제출', className: 'not-approved' };
+            case 3:
+                return { text: '제출승인', className: 'approved' };
+        }
+    };
+
+    const { text, className } = getStateText(item.writingState);
+
+    return (
+        <li className={`writing-item ${className}`} onClick={onClick}>
+            <h3 className="writing-week">{item.title}</h3>
+            <div className='writing-state'>
+                <span className='writing-state-title'>{text}</span>
+                <span className={`writing-state-color ${className}`}></span>
+            </div>
+        </li>
+    );
+}
+
+export default WritingItem;

--- a/src/components/aside/WritingMenu/WritingMenu.css
+++ b/src/components/aside/WritingMenu/WritingMenu.css
@@ -1,0 +1,33 @@
+.writing-menu > h2 {
+    font-size: 14px;
+    color: #fff;
+    font-weight: 500;
+}
+.writing-menu > ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+.total-score-container {
+    background-color: #152A41;
+    border-radius: 10px;
+    padding: 8px 12px;
+    margin-top: 20px;
+    margin-bottom: 10px;
+}
+.total-score-wrapper {
+    color: #fff;
+}
+.total-score-title {
+    font-size: 12px;
+    color: #5E7D9F;
+    font-weight: 500;
+}
+.my-score {
+    font-size: 24px;
+    font-weight: 600;
+}
+.total-score {
+    font-size: 14px;
+    font-weight: 500;
+}

--- a/src/components/aside/WritingMenu/WritingMenu.jsx
+++ b/src/components/aside/WritingMenu/WritingMenu.jsx
@@ -1,0 +1,45 @@
+import './WritingMenu.css';
+import WritingItem from './WritingItem';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useCookies } from 'react-cookie';
+import { getWritingList } from '../../../api/writingApi';
+import useWritingStore from '../../../store/useWritingStore';
+
+function WritingMenu() {
+  const [cookies] = useCookies(['accessToken']);
+  const navigate = useNavigate();
+  const { writingList, myScore, totalScore, setWritingList, updateScores } = useWritingStore();
+
+  useEffect(() => {
+    getWritingList(cookies.accessToken)
+      .then((res) => {
+        const assignmentList = res.data.assignmentList;
+        const myScore = assignmentList.reduce((sum, item) => sum + (item.writingScore || 0), 0);
+        const totalScore = assignmentList.reduce((sum, item) => sum + item.score, 0);
+
+        setWritingList(assignmentList);
+        updateScores(myScore, totalScore);
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  }, [cookies.accessToken]);
+
+  return (
+    <section className='writing-menu'>
+        <h2>주차별 글쓰기</h2>
+        <article className='total-score-container'>
+            <h3 className='total-score-title'>현재 나의 글쓰기 점수</h3>
+            <div className='total-score-wrapper'><span className='my-score'>{myScore}</span> / <span className='total-score'>{totalScore}</span></div>
+        </article>
+        <ul>
+          {writingList.map((item) => (
+              <WritingItem key={item.id} item={item} onClick={() => navigate(`/writing/${item.id}`)} />
+          ))}
+        </ul>
+    </section>
+  );
+}
+
+export default WritingMenu;

--- a/src/hooks/useShowExtend.js
+++ b/src/hooks/useShowExtend.js
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+import useCurrentPath from "./useCurrentPath";
+import useShowExtendStore from "../store/useShowExtendStore";
+import { useLocation } from "react-router-dom";
+
+function useShowExtend() {
+  const currentPath = useCurrentPath();
+  const location = useLocation();
+  const showExtend = useShowExtendStore((state) => state.showExtend);
+  const setShowExtend = useShowExtendStore((state) => state.setShowExtend);
+
+  useEffect(() => {
+    if (
+      currentPath === 'file' || 
+      currentPath === 'writing' 
+    ) {
+      setShowExtend(true);
+    } else {
+      setShowExtend(false);
+    }
+  }, [currentPath, location])
+
+  return showExtend;
+}
+
+export default useShowExtend;

--- a/src/hooks/useWriting.js
+++ b/src/hooks/useWriting.js
@@ -6,7 +6,8 @@ import useWritingStore from '../store/useWritingStore';
 const useWriting = (writingId) => {
     const [cookies] = useCookies(['accessToken']);
     const [content, setContent] = useState('');
-    const [feedbackActive, setFeedbackActive] = useState(false);
+    const [originalContent, setOriginalContent] = useState('');
+    const [isContentModified, setIsContentModified] = useState(false);
     const [assignment, setAssignment] = useState(null);
     const [feedback, setFeedback] = useState('');
     const [writingList] = useWritingStore((state) => [state.writingList, state.setWritingList]);
@@ -15,22 +16,29 @@ const useWriting = (writingId) => {
         const assignment = writingList.find((item) => item.id === parseInt(writingId));
         if (!assignment) return;
         setAssignment(assignment);
-        setFeedbackActive(assignment.writingState === 1);
 
         getWriting(cookies.accessToken, writingId)
             .then((res) => {
                 setContent(res.data.content);
+                setOriginalContent(res.data.content);
+                setIsContentModified(false);
             })
             .catch((error) => {
                 alert(error.message);
             });
     }, [writingId, cookies.accessToken, writingList]);
 
+    const handleContentChange = (newContent) => {
+        setContent(newContent);
+        setIsContentModified(newContent !== originalContent);
+    };
+
     const handleSaveClick = () => {
         postWriting(cookies.accessToken, writingId, 1, content)
             .then(() => {
                 alert('과제가 제출되었습니다.');
-                setFeedbackActive(false);
+                setOriginalContent(content);
+                setIsContentModified(false);
             })
             .catch((error) => {
                 alert(error.message);
@@ -49,12 +57,12 @@ const useWriting = (writingId) => {
 
     return {
         content,
-        setContent,
-        feedbackActive,
         assignment,
         feedback,
         handleSaveClick,
         handleFeedbackClick,
+        isContentModified,
+        handleContentChange,
     };
 };
 

--- a/src/hooks/useWriting.js
+++ b/src/hooks/useWriting.js
@@ -1,0 +1,61 @@
+import { useState, useEffect } from 'react';
+import { useCookies } from 'react-cookie';
+import { postWriting, getWriting, getFeedback } from '../api/writingApi';
+import useWritingStore from '../store/useWritingStore';
+
+const useWriting = (writingId) => {
+    const [cookies] = useCookies(['accessToken']);
+    const [content, setContent] = useState('');
+    const [feedbackActive, setFeedbackActive] = useState(false);
+    const [assignment, setAssignment] = useState(null);
+    const [feedback, setFeedback] = useState('');
+    const [writingList] = useWritingStore((state) => [state.writingList, state.setWritingList]);
+
+    useEffect(() => {
+        const assignment = writingList.find((item) => item.id === parseInt(writingId));
+        if (!assignment) return;
+        setAssignment(assignment);
+        setFeedbackActive(assignment.writingState === 1);
+
+        getWriting(cookies.accessToken, writingId)
+            .then((res) => {
+                setContent(res.data.content);
+            })
+            .catch((error) => {
+                alert(error.message);
+            });
+    }, [writingId, cookies.accessToken, writingList]);
+
+    const handleSaveClick = () => {
+        postWriting(cookies.accessToken, writingId, 1, content)
+            .then(() => {
+                alert('과제가 제출되었습니다.');
+                setFeedbackActive(false);
+            })
+            .catch((error) => {
+                alert(error.message);
+            });
+    };
+
+    const handleFeedbackClick = () => {
+        getFeedback(cookies.accessToken, writingId, content)
+            .then((res) => {
+                setFeedback(res.data.feedback);
+            })
+            .catch((error) => {
+                alert(error.message);
+            });
+    };
+
+    return {
+        content,
+        setContent,
+        feedbackActive,
+        assignment,
+        feedback,
+        handleSaveClick,
+        handleFeedbackClick,
+    };
+};
+
+export default useWriting;

--- a/src/routes/Writing.css
+++ b/src/routes/Writing.css
@@ -29,15 +29,21 @@
 }
 .button-container {
     margin-left: auto;
+    display: flex;
+    flex-direction: row;
 }
 .save-button {
     background-color: #001832;
     color: #fff;
-    width: 72px;
+    min-width: 72px;
     height: 36px;
     border-radius: 10px;
     font-size: 14px;
     cursor: pointer;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
 }
 .feedback-button{
     background-color: #fff;
@@ -134,4 +140,36 @@
     background-color: #888;
     border-radius: 10px;
     border: 2px solid #f0f0f0;
+}
+
+.writing-state-color {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    margin-right: 5px;
+    display: inline-block;
+}
+.writing-state-color.submitted {
+    background-color: #65FF4D;
+}
+.writing-state-color.approved{
+    background-color: #FFA24D;
+}
+.writing-state-color.not-approved{
+    background-color: #FF4D4D;
+}
+.writing-state-color.not-submitted{
+    display: none;
+}
+.writing-score-wrapper {
+    border-left: 1px solid #465F7A;
+    padding-left: 10px;
+    padding-right: 5px;
+    margin-left: 10px;
+}
+.my-writing-score {
+    font-size: 16px;
+}
+.total-writing-score {
+    font-size: 10px;
 }

--- a/src/routes/Writing.css
+++ b/src/routes/Writing.css
@@ -1,0 +1,137 @@
+.writing-main {
+    padding-left: 280px;
+    height: 100dvh;
+    width: 100%;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+}
+.writing-header-container {
+    background-color: #4F6B8A;
+    color: #fff;
+    padding: 10px;
+    padding-left: 350px;
+    font-size: 16px;
+}
+.writing-container {
+    flex: 1;
+    margin: 20px 40px;
+    padding-left: 280px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+.writing-container > hr {
+    border: none;
+    height: 1px;
+    background-color: #E6E8EB;
+    margin: 0;
+}
+.button-container {
+    margin-left: auto;
+}
+.save-button {
+    background-color: #001832;
+    color: #fff;
+    width: 72px;
+    height: 36px;
+    border-radius: 10px;
+    font-size: 14px;
+    cursor: pointer;
+}
+.feedback-button{
+    background-color: #fff;
+    border: 1px solid #001832;
+    color: #001832;
+    width: 72px;
+    height: 36px;
+    border-radius: 10px;
+    font-size: 14px;
+    cursor: pointer;
+    margin-left: 5px;
+}
+.feedback-button.inactive {
+    background-color: #fff;
+    border: 1px solid rgba(0, 24, 50, 0.14);
+    color: rgba(0, 24, 50, 0.14);
+    width: 72px;
+    height: 36px;
+    border-radius: 10px;
+    font-size: 14px;
+    cursor: pointer;
+    margin-left: 5px;
+}
+.writing-description-container {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    padding: 0 10px;
+}
+.description-label {
+    font-size: 14px;
+    color: #000;
+    font-weight: 400;
+    background-color: #F0F1F3;
+    padding: 8px;
+    border-radius: 10px;
+    margin-right: 10px;
+}
+.writing-content-container {
+    display: flex;
+    flex-direction: row;
+    gap: 20px;
+    padding: 0 10px;
+    flex: 1;
+}
+.writing-content-container > hr {
+    border: none;
+    width: 1px;;
+    background-color: #E6E8EB;
+    margin: 0;
+}
+.writing-label {
+    font-size: 14px;
+    color: #000;
+    font-weight: 400;
+    background-color: #F0F1F3;
+    padding: 8px;
+    border-radius: 10px;
+    display: inline-block;
+}
+.writing-content-container > div {
+    width: 50%;
+    display: flex;
+    flex-direction: column;
+}
+.writing-content,
+.feedback-content {
+    border: none;
+    width: 100%;
+    padding: 5px;
+    margin-top: 10px;
+    flex: 1;
+    font-size: 14px;
+    line-height: 20px;
+}
+.writing-content:focus {
+    outline: 1px solid #a7a8ab;
+    border-radius: 5px;
+}
+.feedback-content:focus {
+    outline: none;
+}
+.writing-content::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+}
+
+.writing-content::-webkit-scrollbar-track {
+    background-color: #f0f0f0;
+    border-radius: 10px;
+}
+
+.writing-content::-webkit-scrollbar-thumb {
+    background-color: #888;
+    border-radius: 10px;
+    border: 2px solid #f0f0f0;
+}

--- a/src/routes/Writing.jsx
+++ b/src/routes/Writing.jsx
@@ -2,20 +2,31 @@ import './Writing.css';
 import { useParams } from 'react-router-dom';
 import useWriting from '../hooks/useWriting';
 import { formatAssignmentTime } from '../utils/dateAndTime';
+import { writingStateEnum } from '../utils/writingEnum';
 
 function Writing() {
     const { writingId } = useParams();
     const {
         content,
-        setContent,
-        feedbackActive,
         assignment,
         feedback,
         handleSaveClick,
         handleFeedbackClick,
+        isContentModified,
+        handleContentChange,
     } = useWriting(writingId);
 
     if (!assignment) return <div>Loading...</div>;
+
+    const state = Object.values(writingStateEnum).find(state => state.state === assignment.writingState) || {
+        text: '',
+        className: '',
+    };
+
+    const getSaveButtonText = () => {
+        if (isContentModified) return '다시 제출';
+        return state.text === '' ? '제출' : state.text;
+    };
 
     return (
         <main className='writing-main'>
@@ -25,10 +36,18 @@ function Writing() {
             <section className='writing-container'>
                 <article className='button-container'>
                     <button className='save-button' onClick={handleSaveClick}>
-                        {assignment.writingState === 1 ? '다시제출' : '제출'}
+                        {!isContentModified && <span className={`writing-state-color ${state.className || ''}`}></span>}
+                        {getSaveButtonText()}
+                        {!isContentModified && state.state === 3 && (
+                            <div className='writing-score-wrapper'>
+                                <span className='my-writing-score'>{assignment.writingScore}</span>
+                                /
+                                <span className='total-writing-score'>{assignment.score} 점</span>
+                            </div>
+                        )}
                     </button>
                     <button
-                        className={feedbackActive ? 'feedback-button inactive' : 'feedback-button'}
+                        className={isContentModified ? 'feedback-button inactive' : 'feedback-button'}
                         onClick={handleFeedbackClick}
                     >
                         피드백
@@ -54,7 +73,7 @@ function Writing() {
                         <textarea
                             className='writing-content'
                             value={content}
-                            onChange={(e) => setContent(e.target.value)}
+                            onChange={(e) => handleContentChange(e.target.value)}
                         />
                     </div>
                     <hr />

--- a/src/routes/Writing.jsx
+++ b/src/routes/Writing.jsx
@@ -1,0 +1,75 @@
+import './Writing.css';
+import { useParams } from 'react-router-dom';
+import useWriting from '../hooks/useWriting';
+import { formatAssignmentTime } from '../utils/dateAndTime';
+
+function Writing() {
+    const { writingId } = useParams();
+    const {
+        content,
+        setContent,
+        feedbackActive,
+        assignment,
+        feedback,
+        handleSaveClick,
+        handleFeedbackClick,
+    } = useWriting(writingId);
+
+    if (!assignment) return <div>Loading...</div>;
+
+    return (
+        <main className='writing-main'>
+            <section className='writing-header-container'>
+                <span className='chat-header-text'>{assignment.title}</span>
+            </section>
+            <section className='writing-container'>
+                <article className='button-container'>
+                    <button className='save-button' onClick={handleSaveClick}>
+                        {assignment.writingState === 1 ? '다시제출' : '제출'}
+                    </button>
+                    <button
+                        className={feedbackActive ? 'feedback-button inactive' : 'feedback-button'}
+                        onClick={handleFeedbackClick}
+                    >
+                        피드백
+                    </button>
+                </article>
+                <hr />
+                <article className='writing-description-container'>
+                    <div>
+                        <span className='description-label'>설명</span>
+                        <span className='description-content'>{assignment.description}</span>
+                    </div>
+                    <div>
+                        <span className='description-label'>기간</span>
+                        <span className='description-content'>
+                            {formatAssignmentTime(assignment.startDate, assignment.endDate)}
+                        </span>
+                    </div>
+                </article>
+                <hr />
+                <article className='writing-content-container'>
+                    <div>
+                        <div><span className='writing-label'>나의 글</span></div>
+                        <textarea
+                            className='writing-content'
+                            value={content}
+                            onChange={(e) => setContent(e.target.value)}
+                        />
+                    </div>
+                    <hr />
+                    <div>
+                        <div><span className='writing-label'>피드백</span></div>
+                        <textarea
+                            className='feedback-content'
+                            value={feedback}
+                            readOnly
+                        />
+                    </div>
+                </article>
+            </section>
+        </main>
+    );
+}
+
+export default Writing;

--- a/src/store/useShowExtendStore.js
+++ b/src/store/useShowExtendStore.js
@@ -1,0 +1,8 @@
+import { create } from "zustand";
+
+const useShowExtendStore = create((set) => ({
+  showExtend: false,
+  setShowExtend: (newShowExtend) => set({ showExtend: newShowExtend })
+}))
+
+export default useShowExtendStore;

--- a/src/store/useWritingStore.js
+++ b/src/store/useWritingStore.js
@@ -1,0 +1,12 @@
+import { create } from 'zustand';
+
+const useWritingStore = create((set) => ({
+  writingList: [],
+  myScore: 0,
+  totalScore: 0,
+  setWritingList: (list) => set({ writingList: list }),
+  updateScores: (myScore, totalScore) => set({ myScore, totalScore }),
+}));
+
+
+export default useWritingStore;

--- a/src/utils/dateAndTime.js
+++ b/src/utils/dateAndTime.js
@@ -9,4 +9,23 @@ const formatTime = (dateString) => {
     return date.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' });
 }
 
-export { formatDate, formatTime };
+const formatAssignmentTime = (fromDate, toDate) => {
+    const getFormattedDate = (dateStr) => {
+        const date = new Date(dateStr);
+        const year = date.getFullYear();
+        const month = date.getMonth() + 1;
+        const day = date.getDate();
+
+        const dayOfWeek = ['일', '월', '화', '수', '목', '금', '토'];
+        const dayName = dayOfWeek[date.getDay()];
+
+        return `${year}.${month}.${day}(${dayName})`;
+    };
+
+    const from = getFormattedDate(fromDate);
+    const to = getFormattedDate(toDate);
+
+    return `${from} - ${to}`;
+};
+
+export { formatDate, formatTime, formatAssignmentTime };

--- a/src/utils/writingEnum.js
+++ b/src/utils/writingEnum.js
@@ -1,0 +1,22 @@
+export const writingStateEnum = {
+    NOT_SUBMITTED: {
+        text: '',
+        className: 'not-submitted',
+        state: 0
+    },
+    SUBMITTED: {
+        text: '제출완료',
+        className: 'submitted',
+        state: 1
+    },
+    NOT_APPROVED: {
+        text: '부정제출',
+        className: 'not-approved',
+        state: 2
+    },
+    APPROVED: {
+        text: '제출승인',
+        className: 'approved',
+        state: 3
+    }
+};


### PR DESCRIPTION
- 글쓰기 조회할 때 writingId를 route에 넣고 navigate 했음
        <Route path="/writing" element={<Writing />}>
          <Route path=":writingId" element={<Writing />} />
        </Route>

<img width="1708" alt="image" src="https://github.com/user-attachments/assets/06f12bbd-9cce-443c-b3a8-0df44c59a959">



- 글쓰기 내용을 변경할 때, 버튼은 "다시제출"로 바뀌고 피드팩 버튼은 비활성화됨
- 다시제출 버튼을 클릭하면 피드백 버튼이 활성화되게 했음
- writingState에 따라 button text랑 score 표시했음


<img width="206" alt="image" src="https://github.com/user-attachments/assets/346b1f74-7746-4428-ace1-94dbbd756b15">
<img width="194" alt="image" src="https://github.com/user-attachments/assets/beefe7f5-e860-4013-9f32-012cce3f8561">
<img width="200" alt="image" src="https://github.com/user-attachments/assets/a6272c7d-e809-47d1-848f-5f430308b139">
<img width="265" alt="image" src="https://github.com/user-attachments/assets/15e91950-d9a2-4b74-93dc-27b917bfe2ec">

