### PR TITLE
챗봇, 피드백 큰따옴표(") 선택적 제거 및 챗봇 엔터키 오류 해결

### DIFF
--- a/src/hooks/useChatbot.js
+++ b/src/hooks/useChatbot.js
@@ -19,7 +19,7 @@ function useChatbot() {
   }
 
   const handleTextareaKeyUp = (e) => {
-    if (keys['Enter'] && !keys['Shift']) {
+    if (e.key == 'Enter' && !keys['Shift']) {
       submitBtn.current.click();
     }
     let keysCopy = {...keys};

--- a/src/hooks/useWriting.js
+++ b/src/hooks/useWriting.js
@@ -105,7 +105,25 @@ const useWriting = (writingId) => {
         const content2 = `${content.trim()}\nNumber of Characters: ${content.trim().length}`;
         getFeedback(cookies.accessToken, writingId, content2)
             .then((res) => {
-                setFeedback(res.data.feedback);
+                const response = res.data.feedback;
+                const lastCharIdx = response.length - 1;
+                let feedback = '';
+                if (response[0] === '\"' && response[lastCharIdx] === '\"') {
+                    feedback = response
+                            .slice(1, response.length - 1)
+                            .replace(/""/g, '"')
+                            .replace(/\\"/g, '"')
+                            .replace(/\\n/g, '\n')
+                            .replace(/【\d+:\d+†source】/g, '');
+                } else {
+                    feedback = response
+                        .replace(/""/g, '"')
+                        .replace(/\\"/g, '"')
+                        .replace(/\\n/g, '\n')
+                        .replace(/【\d+:\d+†source】/g, '');
+                }
+                
+                setFeedback(feedback);
                 setIsWaitingForFeedback(false);
             })
             .catch((error) => {

--- a/src/routes/Chatbot.jsx
+++ b/src/routes/Chatbot.jsx
@@ -41,7 +41,10 @@ function Chatbot() {
           {
             chatList.map((item, i) => {
               let formattedAnswer;
-              const lastCharIdx = item.answer.length - 1;
+              let lastCharIdx;
+
+              if (item.answer) lastCharIdx = item.answer.length - 1;
+
               if (item.answer && item.answer[0] === '\"' && item.answer[lastCharIdx] === '\"') {
                 formattedAnswer = item.answer
                 .slice(1, lastCharIdx)
@@ -49,7 +52,7 @@ function Chatbot() {
                 .replace(/\\"/g, '"')
                 .replace(/\\n/g, '\n')
                 .replace(/【\d+:\d+†source】/g, '');
-              } else {
+              } else if (item.answer) {
                 formattedAnswer = item.answer
                 .replace(/""/g, '"')
                 .replace(/\\"/g, '"')

--- a/src/routes/Chatbot.jsx
+++ b/src/routes/Chatbot.jsx
@@ -41,14 +41,22 @@ function Chatbot() {
           {
             chatList.map((item, i) => {
               let formattedAnswer;
-              if (item.answer) {
+              const lastCharIdx = item.answer.length - 1;
+              if (item.answer && item.answer[0] === '\"' && item.answer[lastCharIdx] === '\"') {
                 formattedAnswer = item.answer
-                .slice(1, item.answer.length - 1)
+                .slice(1, lastCharIdx)
+                .replace(/""/g, '"')
+                .replace(/\\"/g, '"')
+                .replace(/\\n/g, '\n')
+                .replace(/【\d+:\d+†source】/g, '');
+              } else {
+                formattedAnswer = item.answer
                 .replace(/""/g, '"')
                 .replace(/\\"/g, '"')
                 .replace(/\\n/g, '\n')
                 .replace(/【\d+:\d+†source】/g, '');
               }
+
               if (!formattedAnswer) {
                 isBotLoading = true;
               }

--- a/src/routes/Writing.jsx
+++ b/src/routes/Writing.jsx
@@ -117,12 +117,7 @@ function Writing() {
                             <textarea
                                 name='feedback-content'
                                 id='feedback-content'
-                                value={feedback
-                                        .slice(1, feedback.length - 1)
-                                        .replace(/""/g, '"')
-                                        .replace(/\\"/g, '"')
-                                        .replace(/\\n/g, '\n')
-                                        .replace(/【\d+:\d+†source】/g, '')}
+                                defaultValue={feedback}
                                 readOnly
                                 ref={feedbackRef}
                                 disabled={isWaitingForFeedback}


### PR DESCRIPTION
## 작업 내용
1. 서버 업데이트로 인해 챗봇 응답과 피드백 응답에서 기존에 응답 앞뒤에 있던 큰 따옴표가 사라져 앞뒤에 한글자씩 잘리는 문제 발생
    - 응답 앞뒤에 큰따옴표가 있을 때만 slice하도록 수정
2. 챗봇에 채팅을 입력하고 난 후에 한 글자만 입력해도 자동으로 채팅이 보내지는 오류 발생
    - 엔터키를 state에 저장해서 state를 확인하지 않고 엔터키는 event key 속성을 바로 참조