### PR TITLE
[Style] 다음 버튼 크기, 카테고리 색깔, 파일 페이지 bottom-padding (#78)

### DIFF
--- a/src/routes/File/File.css
+++ b/src/routes/File/File.css
@@ -7,7 +7,6 @@
 
 .file-main-inner {
   padding-left: 560px;
-  margin: 40px auto;
   display: flex;
   justify-content: center;
 }
@@ -17,6 +16,7 @@
   width: 80%;
   border: none;
   table-layout: fixed;
+  margin: 40px auto;
 }
 
 .file-table tr {
@@ -155,6 +155,7 @@
 
   .file-table {
     width: 95%;
+    margin-top: 0;
   }
 
   .file-table thead {

--- a/src/routes/Register/Register.css
+++ b/src/routes/Register/Register.css
@@ -193,7 +193,7 @@
     padding: 10px 20px;
     font-size: 16px;
     cursor: pointer;
-    width: 296px;
+    width: 100%;
 }
 .register-content-right .next-btn.active {
     background-color: #001832;
@@ -272,7 +272,9 @@
 .info-table td {
     padding: 5px 8px;
 }
-
+.btn-wrapper {
+    width: 100%;
+}
 @media screen and (max-width: 900px) {
     .register-main {
         background-image: none;

--- a/src/routes/Writing/Writing.css
+++ b/src/routes/Writing/Writing.css
@@ -65,6 +65,14 @@
     gap: 20px;
     padding: 0 10px;
 }
+.description-wrapper{
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+.description-content {
+    word-break: keep-all;
+}
 .description-label {
     font-size: 14px;
     color: #000;
@@ -74,6 +82,7 @@
     border-radius: 10px;
     margin-right: 10px;
     word-break: keep-all;
+    margin-bottom: auto;
 }
 .writing-content-container {
     display: flex;

--- a/src/routes/Writing/Writing.jsx
+++ b/src/routes/Writing/Writing.jsx
@@ -64,7 +64,7 @@ function Writing() {
         </article>
         <hr />
         <article className="writing-description-container">
-          <div>
+          <div className="description-wrapper">
             <span className="description-label">설명</span>
             <span className="description-content">
               {assignment.description}

--- a/src/store/useFileStore.js
+++ b/src/store/useFileStore.js
@@ -3,7 +3,7 @@ import { create } from 'zustand'
 const useCategoryStore = create((set) => ({
     categoryList: [],
 
-    colors: ['#E3F1D4','#FFE5E5','#F7F5BA','#E2D7EE','#BADAF7','#FFBCC4','#CDBA9E','#BAF7F4','#FFDB96'],
+    colors: ['#FFD1FA','#E5FFD1','#D1F1FF','#FFFAD1','#EED1FF','#EEEEEE'],
 
     setCategoryList: (id, categoryName) =>
         set((state) => {


### PR DESCRIPTION
1. 회윈가입 페이지에서 "다음" 버튼의 width는 css 말고 %로 수정
2. figma 색을 추출해서 카테고리 색깔 리스트를 변경
3. 파일 페이지 bottom-padding 추가
4. 과제 설명란에다가 display-flex(row) 추가, 글자가 잘리지 않도록 word-break: keep-all 추가
 
<img width="445" alt="image" src="https://github.com/user-attachments/assets/0fd4b73b-ef44-47fc-a7c4-7efa31c7fdb4">
